### PR TITLE
Update @stream-deck-for-node/sdk dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npx ncc build -m ./src/index.ts -o ./plugin"
   },
   "dependencies": {
-  "@stream-deck-for-node/sdk": "^1.0.0"
+  "@stream-deck-for-node/sdk": "^1.0.4"
   },
   "devDependencies": {
     "ts-node": "^10.4.0",


### PR DESCRIPTION
Allows the sample plugin to install.

```
npm ERR! notarget No matching version found for @stream-deck-for-node/sdk@1.0.2.
```